### PR TITLE
Docker can't find app.sh file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     env_file:
       - .env-non-dev
     container_name: betarget
-    command: ["/betarget/docker/app.sh"]
+    command: ["sh", "/betarget/docker/app.sh"]
     ports:
       - 9999:8080
     depends_on:


### PR DESCRIPTION
Adding extra option "sh" inside docker app's service "command" field.